### PR TITLE
Fix test and update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ elixir:
     - 1.2
     - 1.3
     - 1.4
+    - 1.5
+    - 1.6
 sudo: false
 otp_release:
     - 18.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: elixir
 elixir:
-    - 1.2
     - 1.3
     - 1.4
     - 1.5
@@ -16,3 +15,5 @@ matrix:
       otp_release: 20.0
     - elixir: 1.3
       otp_release: 20.0
+    - elixir: 1.6
+      otp_release: 18.3

--- a/lib/plug_cloudflare.ex
+++ b/lib/plug_cloudflare.ex
@@ -20,7 +20,7 @@ defmodule Plug.CloudFlare do
 
   defp parse([], conn), do: conn
   defp parse([ip_address], conn) do
-    case (ip_address |> String.to_char_list |> :inet.parse_address) do
+    case (ip_address |> String.to_charlist |> :inet.parse_address) do
       {:ok, remote_ip} -> %Conn{conn | remote_ip: remote_ip}
       {:error, _}      -> conn
     end

--- a/test/plug_cloudflare_test.exs
+++ b/test/plug_cloudflare_test.exs
@@ -21,6 +21,10 @@ defmodule Plug.CloudFlareTest do
 
   @opts TestRouter.init([])
 
+  setup do
+    Application.put_env(:plug, :validate_header_keys_during_test, true)
+  end
+
   test "sets remote_ip correctly" do
     conn = conn(:get, "/") |> put_req_header("cf-connecting-ip", "192.168.1.1")
     conn = %Plug.Conn{conn | remote_ip: {103, 21, 244, 0}}


### PR DESCRIPTION
- Fix failed tests when missing plug validation header keys in test environment
- Remove elixir 1.2 in travis CI ( some package require elixir 1.3)
- Ignore OTP 18.3 for elixir 1.6