### PR TITLE
Include runtime dependencies

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -35,6 +35,6 @@ defmodule Plug.Cloudflare.Mixfile do
   end
 
   def application do
-    [applications: []]
+    [applications: [:cidr, :plug]]
   end
 end


### PR DESCRIPTION
I opted for manually including runtime dependencies rather than letting elixir infer them for backwards compatibility with older versions of elixir.

I tested this on our application by removing `cidr` from the list of declared runtime dependencies and it appears to be working.

See the related change here https://github.com/elixir-lang/elixir/pull/5473.
Resolves #15