### PR TITLE
Add support for IPv4-mapped IPv6 addresses (RFC4291 section 2.5.5.2)

### DIFF
--- a/lib/plug_cloudflare.ex
+++ b/lib/plug_cloudflare.ex
@@ -10,7 +10,7 @@ defmodule Plug.CloudFlare do
 
   @doc "Callback implementation for Plug.call/2"
   def call(conn, _options) do
-    if conn.remote_ip |> is_from_cloudflare do
+    if is_from_cloudflare(conn.remote_ip) do
       conn |> Conn.get_req_header("cf-connecting-ip") |> parse(conn)
     else
       conn

--- a/lib/plug_cloudflare.ex
+++ b/lib/plug_cloudflare.ex
@@ -44,6 +44,12 @@ defmodule Plug.CloudFlare do
 
   defp is_from_cloudflare({_, _, _, _} = ip), do: is_from_cloudflare(unquote(cidrs_v4), ip)
 
+  # See RFC4291 Section 2.5.5.2 (https://tools.ietf.org/html/rfc4291#section-2.5.5.2)
+  defp is_from_cloudflare({0, 0, 0, 0, 0, 65535, _, _} = ipv4_mapped_ipv6) do
+    ip = :inet.ipv4_mapped_ipv6_address(ipv4_mapped_ipv6)
+    is_from_cloudflare(unquote(cidrs_v4), ip)
+  end
+
   defp is_from_cloudflare({_, _, _, _, _, _, _, _} = ip),
     do: is_from_cloudflare(unquote(cidrs_v6), ip)
 


### PR DESCRIPTION
Adds support for IPv4-mapped IPv6 addresses as described in https://tools.ietf.org/html/rfc4291#section-2.5.5.2

This is especially useful if a server is bound do `listen: {0, 0, 0, 0, 0, 0, 0, 0}`, in which case all incoming IPv4 traffic would have their IP address mapped to IPv6.

This change would be a breaking change for anyone using OTP=<21 (https://erlang.org/doc/man/inet.html#ipv4_mapped_ipv6_address-1)